### PR TITLE
[WIP] Use the static protobuf for Windows package

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,23 @@
-  
-set "ONNX_ML=1"
-set CONDA_PREFIX=%LIBRARY_PREFIX%
 set CMAKE_GENERATOR="Visual Studio 15 2017"
+set PYTHON_EXECUTABLE=%PYTHON%
+set PYTHON_LIBRARIES=%LIBRARY_LIB%
+set CONDA_PREFIX=%LIBRARY_PREFIX%
+set ROOT_DIR=%cd%
+set PROTOBUF_INSTALL_DIR=%root_dir%\protobuf\install
+
+# Install static protobuf 
+# Default using the latest protobuf
+git clone https://github.com/protocolbuffers/protobuf.git
+cd protobuf
+cd cmake
+cmake -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=%PROTOBUF_INSTALL_DIR%
+msbuild protobuf.sln /m /p:Configuration=Release
+msbuild INSTALL.vcxproj /p:Configuration=Release
+set "PATH=%PROTOBUF_INSTALL_DIR%\bin;%PATH"
+cd %ROOT_DIR%
+
+set ONNX_ML=1
 set CMAKE_BUILD_TYPE=Release
-set CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON"
-set "PYTHON_EXECUTABLE=%PYTHON%"
-set "PYTHON_LIBRARIES=%LIBRARY_LIB%"
+set CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON"
 set USE_MSVC_STATIC_RUNTIME=0
 %PYTHON% -m pip install --no-deps --no-use-pep517 --ignore-installed --verbose .

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,7 @@ cd cmake
 cmake -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=%PROTOBUF_INSTALL_DIR%
 msbuild protobuf.sln /m /p:Configuration=Release
 msbuild INSTALL.vcxproj /p:Configuration=Release
-set "PATH=%PROTOBUF_INSTALL_DIR%\bin;%PATH"
+set "PATH=%PROTOBUF_INSTALL_DIR%\bin;%PATH%"
 cd %ROOT_DIR%
 
 set ONNX_ML=1


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The previous PR about Windows is using shared protobuf. However, other release onnx packages like PyPI are using static protobuf. It would be better that each released onnx package is using protobuf in the same way. Therefore, this PR is trying to build the conda onnx package with static protobuf.

Another question: The previous PR about Windows does not update the conda-forge package for ` win-32`.


cc @askhade