### PR TITLE
Upgrade ONNX to 1.13

### DIFF
--- a/recipe/4535-relax_protobuf_to_under_4.patch
+++ b/recipe/4535-relax_protobuf_to_under_4.patch
@@ -1,0 +1,9 @@
+diff --git a/requirements.txt b/requirements.txt
+index 21817ca808..3d597e4b5f 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,3 +1,3 @@
+ numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
+-protobuf >= 3.12.2, <= 3.20.1
++protobuf
+ typing-extensions >= 3.6.2.1

--- a/recipe/4535-relax_protobuf_to_under_4.patch
+++ b/recipe/4535-relax_protobuf_to_under_4.patch
@@ -1,9 +1,0 @@
-diff --git a/requirements.txt b/requirements.txt
-index 21817ca808..3d597e4b5f 100644
---- a/requirements.txt
-+++ b/requirements.txt
-@@ -1,3 +1,3 @@
- numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
--protobuf >= 3.12.2, <= 3.20.1
-+protobuf
- typing-extensions >= 3.6.2.1

--- a/recipe/4535-relax_protobuf_to_under_4.patch
+++ b/recipe/4535-relax_protobuf_to_under_4.patch
@@ -1,9 +1,21 @@
+From c4adb29f29bf1703f39b87eac193367c2b517340 Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Tue, 13 Dec 2022 21:24:16 +0100
+Subject: [PATCH] Relax protobuf range
+
+---
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/requirements.txt b/requirements.txt
-index 21817ca808..3d597e4b5f 100644
+index 5e98ada..aa14d94 100644
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,3 +1,3 @@
  numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
--protobuf >= 3.12.2, <= 3.20.1
+-protobuf >= 3.20.2, < 4
 +protobuf
  typing-extensions >= 3.6.2.1
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
 export ONNX_ML=1
 # build script looks at this, but not set on
 export CONDA_PREFIX="$PREFIX"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy
   run:
     - python
-    - protobuf >=3.20.2,<4
+    - protobuf
     - {{ pin_compatible('numpy') }}
     - typing-extensions >=3.6.2.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,6 @@ package:
 source:
   url: https://github.com/onnx/onnx/archive/v{{ version }}.tar.gz
   sha256: 66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978
-  patches:
-    - 4535-relax_protobuf_to_under_4.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/onnx/onnx/archive/v{{ version }}.tar.gz
   sha256: 66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978
+  patches:
+    - 4535-relax_protobuf_to_under_4.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - python
     - protobuf
     - {{ pin_compatible('numpy') }}
-    - six
     - typing-extensions >=3.6.2.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "onnx" %}
-{% set version = "1.12.0" %}
+{% set version = "1.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/onnx/onnx/archive/v{{ version }}.tar.gz
-  sha256: 052ad3d5dad358a33606e0fc89483f8150bb0655c99b12a43aa58b5b7f0cc507
+  sha256: 410b39950367857f97b65093681fe2495a2e23d63777a8aceaf96c56a16d166e
   patches:
     - 4535-relax_protobuf_to_under_4.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy
   run:
     - python
-    - protobuf
+    - protobuf >=3.20.2,<4
     - {{ pin_compatible('numpy') }}
     - typing-extensions >=3.6.2.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/onnx/onnx/archive/v{{ version }}.tar.gz
-  sha256: 410b39950367857f97b65093681fe2495a2e23d63777a8aceaf96c56a16d166e
+  sha256: 66eb61fc0ff4b6189816eb8e4da52e1e6775a1c29f372cbd08b694aa5b4ca978
   patches:
     - 4535-relax_protobuf_to_under_4.patch
 


### PR DESCRIPTION
Signed-off-by: p-wysocki <przemyslaw.wysocki@intel.com>

ONNX 1.13 has been released: https://github.com/onnx/onnx/releases/tag/v1.13.0

Reference PR: https://github.com/conda-forge/onnx-feedstock/pull/1