### PR TITLE
Ignore v12.0.0 for autotick bot

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,8 @@
 bot:
   run_deps_from_wheel: true
+  version_updates:
+    exclude:
+      - "12.0.0"
 build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true


### PR DESCRIPTION
The autotick bot is currently broken for this feedstock. This is an attempt to fix it.

More details [here](https://github.com/regro/cf-graph-countyfair/pull/2).